### PR TITLE
Swap `fgrep` for `string match`

### DIFF
--- a/functions/__fish_tmsu_database.fish
+++ b/functions/__fish_tmsu_database.fish
@@ -30,5 +30,5 @@ function __fish_tmsu_database -d 'Return active tmsu DB, given commandline args'
     __fish_expand_userdir "$TMSU_DB"
     return
   end
-  tmsu info 2>/dev/null | fgrep Database: | cut -d ' ' -f 2-
+  tmsu info 2>/dev/null | string match 'Database: *' | cut -d ' ' -f 2-
 end


### PR DESCRIPTION
As of GNU grep 3.8, `fgrep` is obsolete and echoes a warning to stderr. Fish's built-in `string match` command can be used instead.